### PR TITLE
Add "allow-empty" parameter to "git commit" command

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function buildAndPublish(version) {
   exec(`npm run-script ${BUILD_SCRIPT}`);
   exec(`git add ${DIST_DIR} -f`);
   const commitMessage = COMMIT_MESSAGE.replace('%ver%', version);
-  exec(`git commit -m "${commitMessage}"`);
+  exec(`git commit -m "${commitMessage}" --allow-empty`);
   exec(`git tag v${version}`);
   let remote = 'origin';
   if (GH_TOKEN) {


### PR DESCRIPTION
Hi @RomanHotsiy,

as discussed in #1, I have now added the allow-empty flag to the "git commit" command in order to fix releases that do not affect the "dist" files, but might have an impact on the environment, for example adding some "dependencies" to the package.json file.

To see the working fix in action, please follow these steps:

1. Fork https://github.com/stefanullinger/branch-release--allow-empty
2. Run `npm install`
3. Update the version number in the `package.json` file. Imagine that you would have added some files here or made changes to existing files, that do not directly have an impact on the "dist" files, e.g. adding a README file, adding some package dependencies that are required to be installed when using this package.
4. Commit your changes.
5. Run `npm run release`.

The release should be created without any errors.

Fixes #1 